### PR TITLE
FlakeHub: support uploading existing tags

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,17 +1,26 @@
+name: "Publish tags to FlakeHub"
 on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The existing tag to publish to FlakeHub"
+        type: "string"
+        required: true
 jobs:
-  publish:
+  flakehub-publish:
     runs-on: "ubuntu-latest"
     permissions:
       id-token: "write"
       contents: "read"
     steps:
       - uses: "actions/checkout@v3"
+        with:
+          ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
       - uses: "DeterminateSystems/nix-installer-action@main"
       - uses: "DeterminateSystems/flakehub-push@main"
         with:
           visibility: "public"
-          name: "divnix/std"
+          tag: "${{ inputs.tag }}"


### PR DESCRIPTION
If you're interested, you can publish existing tags using this updated workflow. Once this merges, you can go to the workflow on GitHub at https://github.com/divnix/std/actions/workflows/flakehub-publish-tagged.yml, click "Run workflow", and then type in -- for example -- `v0.24.0-1` or `v0.23.2`.

I hope that helps!

(also note that it'll automatically upload as divnix/std if it is published from divnix/std, no need to specify the `name` key if you don't want to 👍.)